### PR TITLE
Include a check for the index's size before trying to access it

### DIFF
--- a/tablexplore/core.py
+++ b/tablexplore/core.py
@@ -2068,17 +2068,19 @@ class DataFrameModel(QtCore.QAbstractTableModel):
 
         if role == QtCore.Qt.DisplayRole:
             if orientation == QtCore.Qt.Horizontal:
-                return str(self.df.columns[col])
-            if orientation == QtCore.Qt.Vertical:
-                value = self.df.index[col]
-                if type( self.df.index) == pd.DatetimeIndex:
-                    if not value is pd.NaT:
-                        try:
-                            return value.strftime(TIMEFORMAT)
-                        except:
-                            return ''
-                else:
-                    return str(value)
+                if col < len(self.df.columns):
+                    return str(self.df.columns[col])
+            elif orientation == QtCore.Qt.Vertical:
+                if col < len(self.df.index):
+                    value = self.df.index[col]
+                    if type(self.df.index) == pd.DatetimeIndex:
+                        if value is not pd.NaT:
+                            try:
+                                return value.strftime(TIMEFORMAT)
+                            except:
+                                return ''
+                    else:
+                        return str(value)
         return None
 
     def setData(self, index, value, role=QtCore.Qt.EditRole):


### PR DESCRIPTION
I was trying to run the app with Python 3.11.4 and some actions like Import a .csv, clear and transpose a table would throw an IndexError.

The solution in the pull-request checks whether col is less than the length of the columns or the index, depending on the orientation, before trying to access the value. If col is out of bounds, it will simply return None, avoiding the IndexError.